### PR TITLE
Use 0 to indicate unlimited timestampAgeLimit.

### DIFF
--- a/src/main/java/net/sourceforge/guacamole/net/hmac/HmacAuthenticationProvider.java
+++ b/src/main/java/net/sourceforge/guacamole/net/hmac/HmacAuthenticationProvider.java
@@ -147,9 +147,14 @@ public class HmacAuthenticationProvider extends SimpleAuthenticationProvider {
     }
 
     private boolean checkTimestamp(String ts) {
+        if (timestampAgeLimit == 0) {
+            return true;
+        }
+
         if (ts == null) {
             return false;
         }
+
         long timestamp = Long.parseLong(ts, 10);
         long now = timeProvider.currentTimeMillis();
         return timestamp + timestampAgeLimit > now;


### PR DESCRIPTION
Allow a valid request to not expire by setting timestampAgeLimit to 0 in the properties file.
